### PR TITLE
Change Google Drive table parsing structure

### DIFF
--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/canonical/specs-v2.canonical.com/config"
 	"github.com/canonical/specs-v2.canonical.com/db"
-	"github.com/canonical/specs-v2.canonical.com/googledrive"
+	"github.com/canonical/specs-v2.canonical.com/google"
 	"github.com/canonical/specs-v2.canonical.com/specs"
 )
 
@@ -31,7 +31,7 @@ func main() {
 
 	logger.Info("migrations completed successfully")
 
-	googleDrive, err := googledrive.NewGoogleDrive(googledrive.Config{
+	googleDrive, err := google.NewGoogleDrive(google.Config{
 		ClientID:          "112404606310881291739",
 		ClientEmail:       "specs-reader@roadmap-270011.iam.gserviceaccount.com",
 		ClientX509CertURL: "https://www.googleapis.com/robot/v1/metadata/x509/specs-reader%40roadmap-270011.iam.gserviceaccount.com",

--- a/google/fields.go
+++ b/google/fields.go
@@ -1,4 +1,4 @@
-package googledrive
+package google
 
 import (
 	"fmt"

--- a/google/query.go
+++ b/google/query.go
@@ -1,4 +1,4 @@
-package googledrive
+package google
 
 import (
 	"fmt"

--- a/specs/parser.go
+++ b/specs/parser.go
@@ -60,48 +60,51 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 		SyncedAt:           time.Now(),
 	}
 
-	specsMetadatabTable, err := s.DriveClient.DocumentFirstTable(ctx, file.File.Id)
-	if err != nil {
-		return fmt.Errorf("failed to get first table: %w", err)
-	}
-	logger.Debug("metadata table", "table", specsMetadatabTable)
-	for key, values := range specsMetadatabTable {
-		switch key {
-		case "title":
-			if specTitle == "" {
-				specTitle = values[0]
-			}
-		case "index":
-			if specId == "" {
-				specId = values[0]
-			}
-		case "status":
-			newSpec.Status = &values[0]
-		case "authors":
-			newSpec.Authors = []string{}
-			for _, value := range values {
-				for _, author := range strings.FieldsFunc(value, AuthorsSplit) {
-					// remove email <..@..>
-					author = strings.TrimSpace(author)
-					author = strings.Split(author, "<")[0]
-					author = strings.TrimSpace(author)
+	// specsMetadatabTable, err := s.GoogleClient.DocumentFirstTable(ctx, file.File.Id)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to get first table: %w", err)
+	// }
 
-					// remove (PjM)..
-					if strings.HasPrefix(author, "(") {
-						continue
-					}
+	// TODO: update table parsing to use the new table format
 
-					formattedAuthor := strings.TrimSpace(author)
-					authorValid := len(formattedAuthor) > 4
-					if authorValid {
-						newSpec.Authors = append(newSpec.Authors, formattedAuthor)
-					}
-				}
-			}
-		case "type":
-			newSpec.SpecType = &values[0]
-		}
-	}
+	// for key, values := range specsMetadatabTable {
+	// 	switch key {
+	// 	case "title":
+	// 		if specTitle == "" {
+	// 			specTitle = values[0]
+	// 		}
+	// 	case "index":
+	// 		if specId == "" {
+	// 			specId = values[0]
+	// 		}
+	// 	case "status":
+	// 		newSpec.Status = &values[0]
+	// 	case "authors":
+	// 		newSpec.Authors = []string{}
+	// 		for _, value := range values {
+	// 			for _, author := range strings.FieldsFunc(value, AuthorsSplit) {
+	// 				// remove email <..@..>
+	// 				author = strings.TrimSpace(author)
+	// 				author = strings.Split(author, "<")[0]
+	// 				author = strings.TrimSpace(author)
+
+	// 				// remove (PjM)..
+	// 				if strings.HasPrefix(author, "(") {
+	// 					continue
+	// 				}
+
+	// 				formattedAuthor := strings.TrimSpace(author)
+	// 				authorValid := len(formattedAuthor) > 4
+	// 				if authorValid {
+	// 					newSpec.Authors = append(newSpec.Authors, formattedAuthor)
+	// 				}
+	// 			}
+	// 		}
+	// 	case "type":
+	// 		newSpec.SpecType = &values[0]
+	// 	}
+	// }
+
 	logger.Debug("creating spec", "specs", newSpec)
 	if err := s.DB.Where(db.Spec{ID: newSpec.ID}).Assign(newSpec).FirstOrCreate(&newSpec).Error; err != nil {
 		return fmt.Errorf("failed to upsert spec: %w", err)


### PR DESCRIPTION
## Done

- Rename package `googledrive` to `google`
- Change `google.DocumentFirstTable` return structure:
- Change authors, reviewers respresentation instead of names now we use emails

### For a given table:

| authors | User1, User2, User3 |
|---|---|
| created | 2021-09-13 |
| index | SN114 |

**Previous format:**

```json
{
  "authors": ["User1, User2, User3"],
  "created": ["2021-09-13"],
  "index": ["SN114"],
}
```
  
**New format:**

```json
[
	["authors", "user1@canonical,user2@canonical.com,user3@canonical"],
	["created", "2021-09-13"],
	["index", "SN114"]
]
```

### New specs template with new format:

```json
[
	["Index", "PR001", "", ""],
	["Title", "Specifications - Purpose and Guidance"],
	["Type", "Author(s)", "Status", "Created"],
	[
		"Process",
		"user1@canonical.com,user2@canonical.com,user3@canonical.com",
		"Approved",
		"Apr 22, 2021"
	],
	["", "Reviewer(s)", "Status", "Date"],
	["", "user4@canonical.com", "Approved", "Aug 11, 2023"],
	["", "user3@canonical.com", "Approved", "Aug 11, 2023"],
	["", "user2@canonical.com", "Approved", "Aug 11, 2023"],
	["", "user1@canonical.com", "Approved", "Jul 11, 2023"]
]

```