### PR TITLE
Change google table parsing ext

### DIFF
--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/canonical/specs-v2.canonical.com/config"
 	"github.com/canonical/specs-v2.canonical.com/db"
-	"github.com/canonical/specs-v2.canonical.com/googledrive"
+	"github.com/canonical/specs-v2.canonical.com/google"
 	"github.com/canonical/specs-v2.canonical.com/specs"
 )
 
@@ -31,7 +31,7 @@ func main() {
 
 	logger.Info("migrations completed successfully")
 
-	googleDrive, err := googledrive.NewGoogleDrive(googledrive.Config{
+	googleDrive, err := google.NewGoogleDrive(google.Config{
 		ClientID:          "112404606310881291739",
 		ClientEmail:       "specs-reader@roadmap-270011.iam.gserviceaccount.com",
 		ClientX509CertURL: "https://www.googleapis.com/robot/v1/metadata/x509/specs-reader%40roadmap-270011.iam.gserviceaccount.com",

--- a/google/fields.go
+++ b/google/fields.go
@@ -1,4 +1,4 @@
-package googledrive
+package google
 
 import (
 	"fmt"

--- a/google/helpers.go
+++ b/google/helpers.go
@@ -144,7 +144,27 @@ func (g *Google) ExportFile(ctx context.Context, fileID string, format string) (
 	return markdown, nil
 }
 
-// DocumentFirstTable gets the first table in a Google Doc
+// DocumentFirstTable extracts the first table from a Google Document and converts it into a 2D string array.
+// It takes a context and a file ID as input parameters and returns a 2D slice of strings representing
+// the table's content.
+//
+// The function performs the following steps:
+// 1. Exports the Google Document as HTML using the provided file ID.
+// 2. Parses the HTML content to find the first table element.
+// 3. Iterates over each row ("tr") in the table.
+// 4. For each row, extracts the text content from each cell ("th" and "td").
+// 5. If a cell contains mailto links, it extracts the email addresses and joins them with commas.
+// 6. Appends the extracted row data to the result slice.
+//
+// If no table is found or no data could be extracted, it returns an error.
+//
+// Parameters:
+// - ctx: The context for the request.
+// - fileID: The ID of the Google Document file.
+//
+// Returns:
+// - A 2D slice of strings representing the table's content.
+// - An error if any issues occur during the extraction process.
 func (g *Google) DocumentFirstTable(ctx context.Context, fileID string) ([][]string, error) {
 	content, err := g.ExportFile(ctx, fileID, MimeTypeHTML)
 	if err != nil {

--- a/google/query.go
+++ b/google/query.go
@@ -1,4 +1,4 @@
-package googledrive
+package google
 
 import (
 	"fmt"

--- a/specs/parser.go
+++ b/specs/parser.go
@@ -16,10 +16,8 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 
 	logger.Debug("processing file")
 
-	// google doc title: format {id} - {title}
 	parts := strings.SplitN(file.File.Name, "-", 2)
-	var specId string
-	var specTitle string
+	var specId, specTitle string
 	if len(parts) == 2 {
 		specId, specTitle = strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 	}
@@ -36,7 +34,6 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 	}
 	googleDocCreatedAt := parsedTime
 
-	// check if spec hasn't changed since last sync
 	if !s.Config.ForceSync {
 		var updatedAt time.Time
 		s.DB.Model(&db.Spec{}).Where("id = ?", specId).Pluck("google_doc_updated_at", &updatedAt)
@@ -60,50 +57,21 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 		SyncedAt:           time.Now(),
 	}
 
-	// specsMetadatabTable, err := s.GoogleClient.DocumentFirstTable(ctx, file.File.Id)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to get first table: %w", err)
-	// }
+	specsMetadataTable, err := s.GoogleClient.DocumentFirstTable(ctx, file.File.Id)
+	if err != nil {
+		return fmt.Errorf("failed to get first table: %w", err)
+	}
+	logger.Debug("metadata table", "table", specsMetadataTable)
 
-	// TODO: update table parsing to use the new table format
+	if len(specsMetadataTable) == 0 {
+		return fmt.Errorf("metadata table is empty")
+	}
 
-	// for key, values := range specsMetadatabTable {
-	// 	switch key {
-	// 	case "title":
-	// 		if specTitle == "" {
-	// 			specTitle = values[0]
-	// 		}
-	// 	case "index":
-	// 		if specId == "" {
-	// 			specId = values[0]
-	// 		}
-	// 	case "status":
-	// 		newSpec.Status = &values[0]
-	// 	case "authors":
-	// 		newSpec.Authors = []string{}
-	// 		for _, value := range values {
-	// 			for _, author := range strings.FieldsFunc(value, AuthorsSplit) {
-	// 				// remove email <..@..>
-	// 				author = strings.TrimSpace(author)
-	// 				author = strings.Split(author, "<")[0]
-	// 				author = strings.TrimSpace(author)
-
-	// 				// remove (PjM)..
-	// 				if strings.HasPrefix(author, "(") {
-	// 					continue
-	// 				}
-
-	// 				formattedAuthor := strings.TrimSpace(author)
-	// 				authorValid := len(formattedAuthor) > 4
-	// 				if authorValid {
-	// 					newSpec.Authors = append(newSpec.Authors, formattedAuthor)
-	// 				}
-	// 			}
-	// 		}
-	// 	case "type":
-	// 		newSpec.SpecType = &values[0]
-	// 	}
-	// }
+	if isColumnFormat(specsMetadataTable) {
+		parseColumnBasedMetadata(specsMetadataTable, &newSpec)
+	} else {
+		parseRowBasedMetadata(specsMetadataTable, &newSpec)
+	}
 
 	logger.Debug("creating spec", "specs", newSpec)
 	if err := s.DB.Where(db.Spec{ID: newSpec.ID}).Assign(newSpec).FirstOrCreate(&newSpec).Error; err != nil {
@@ -111,6 +79,98 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 	}
 
 	return nil
+}
+
+func isColumnFormat(table [][]string) bool {
+	expectedKeys := []string{"type", "author(s)", "status", "created"}
+	if len(table) < 4 {
+		return false
+	}
+
+	foundKeys := 0
+	for _, cell := range table[2] {
+		for _, expected := range expectedKeys {
+			if strings.EqualFold(cell, expected) {
+				foundKeys++
+				break
+			}
+		}
+	}
+	return foundKeys == len(expectedKeys)
+}
+
+func parseRowBasedMetadata(table [][]string, spec *db.Spec) {
+	for _, row := range table {
+		if len(row) < 2 {
+			continue
+		}
+		key := strings.ToLower(row[0])
+		value := row[1]
+
+		switch key {
+		case "title":
+			if spec.Title == nil || *spec.Title == "" {
+				spec.Title = &value
+			}
+		case "index":
+			if spec.ID == "" {
+				spec.ID = value
+			}
+		case "status":
+			spec.Status = &value
+		case "authors":
+			spec.Authors = parseAuthors([]string{value})
+		case "type":
+			spec.SpecType = &value
+		}
+	}
+}
+
+func parseColumnBasedMetadata(table [][]string, spec *db.Spec) {
+	if len(table) < 4 {
+		return
+	}
+
+	keysRow := table[2]
+	valuesRow := table[3]
+	if len(keysRow) != len(valuesRow) {
+		return
+	}
+
+	for i, key := range keysRow {
+		key = strings.ToLower(key)
+		value := valuesRow[i]
+
+		switch key {
+		case "title":
+			if spec.Title == nil || *spec.Title == "" {
+				spec.Title = &value
+			}
+		case "index":
+			if spec.ID == "" {
+				spec.ID = value
+			}
+		case "status":
+			spec.Status = &value
+		case "author(s)":
+			spec.Authors = parseAuthors([]string{value})
+		case "type":
+			spec.SpecType = &value
+		}
+	}
+}
+
+func parseAuthors(values []string) []string {
+	authors := []string{}
+	for _, value := range values {
+		for _, author := range strings.FieldsFunc(value, AuthorsSplit) {
+			author = strings.TrimSpace(strings.Split(author, "<")[0])
+			if len(author) > 4 {
+				authors = append(authors, author)
+			}
+		}
+	}
+	return authors
 }
 
 func AuthorsSplit(r rune) bool {

--- a/specs/parser.go
+++ b/specs/parser.go
@@ -60,48 +60,51 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 		SyncedAt:           time.Now(),
 	}
 
-	specsMetadatabTable, err := s.DriveClient.DocumentFirstTable(ctx, file.File.Id)
-	if err != nil {
-		return fmt.Errorf("failed to get first table: %w", err)
-	}
-	logger.Debug("metadata table", "table", specsMetadatabTable)
-	for key, values := range specsMetadatabTable {
-		switch key {
-		case "title":
-			if specTitle == "" {
-				specTitle = values[0]
-			}
-		case "index":
-			if specId == "" {
-				specId = values[0]
-			}
-		case "status":
-			newSpec.Status = &values[0]
-		case "authors":
-			newSpec.Authors = []string{}
-			for _, value := range values {
-				for _, author := range strings.FieldsFunc(value, AuthorsSplit) {
-					// remove email <..@..>
-					author = strings.TrimSpace(author)
-					author = strings.Split(author, "<")[0]
-					author = strings.TrimSpace(author)
+	// specsMetadatabTable, err := s.GoogleClient.DocumentFirstTable(ctx, file.File.Id)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to get first table: %w", err)
+	// }
 
-					// remove (PjM)..
-					if strings.HasPrefix(author, "(") {
-						continue
-					}
+	// TODO: update table parsing to use the new table format
 
-					formattedAuthor := strings.TrimSpace(author)
-					authorValid := len(formattedAuthor) > 4
-					if authorValid {
-						newSpec.Authors = append(newSpec.Authors, formattedAuthor)
-					}
-				}
-			}
-		case "type":
-			newSpec.SpecType = &values[0]
-		}
-	}
+	// for key, values := range specsMetadatabTable {
+	// 	switch key {
+	// 	case "title":
+	// 		if specTitle == "" {
+	// 			specTitle = values[0]
+	// 		}
+	// 	case "index":
+	// 		if specId == "" {
+	// 			specId = values[0]
+	// 		}
+	// 	case "status":
+	// 		newSpec.Status = &values[0]
+	// 	case "authors":
+	// 		newSpec.Authors = []string{}
+	// 		for _, value := range values {
+	// 			for _, author := range strings.FieldsFunc(value, AuthorsSplit) {
+	// 				// remove email <..@..>
+	// 				author = strings.TrimSpace(author)
+	// 				author = strings.Split(author, "<")[0]
+	// 				author = strings.TrimSpace(author)
+
+	// 				// remove (PjM)..
+	// 				if strings.HasPrefix(author, "(") {
+	// 					continue
+	// 				}
+
+	// 				formattedAuthor := strings.TrimSpace(author)
+	// 				authorValid := len(formattedAuthor) > 4
+	// 				if authorValid {
+	// 					newSpec.Authors = append(newSpec.Authors, formattedAuthor)
+	// 				}
+	// 			}
+	// 		}
+	// 	case "type":
+	// 		newSpec.SpecType = &values[0]
+	// 	}
+	// }
+
 	logger.Debug("creating spec", "specs", newSpec)
 	if err := s.DB.Where(db.Spec{ID: newSpec.ID}).Assign(newSpec).FirstOrCreate(&newSpec).Error; err != nil {
 		return fmt.Errorf("failed to upsert spec: %w", err)

--- a/specs/parser.go
+++ b/specs/parser.go
@@ -81,6 +81,37 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 	return nil
 }
 
+// isColumnFormat checks if the given table has the old specification design or the new one.
+// Old design is row-based, where each row contains a key-value pair. Where the table will look like:
+/*
+[
+ 	["authors", "user1@canonical,user2@canonical.com,user3@canonical"],
+	["created", "2021-09-13"],
+	["index", "SN114"]
+]
+*/
+// And the new design is column-based, where the table will look like:
+/*
+[
+	["Index", "PR001", "", ""],
+	["Title", "Specifications - Purpose and Guidance"],
+	["Type", "Author(s)", "Status", "Created"],
+	[
+		"Process",
+		"user1@canonical.com,user2@canonical.com,user3@canonical.com",
+		"Approved",
+		"Apr 22, 2021"
+	],
+	["", "Reviewer(s)", "Status", "Date"],
+	["", "user4@canonical.com", "Approved", "Aug 11, 2023"],
+	["", "user3@canonical.com", "Approved", "Aug 11, 2023"],
+	["", "user2@canonical.com", "Approved", "Aug 11, 2023"],
+	["", "user1@canonical.com", "Approved", "Jul 11, 2023"]
+]
+*/
+// The function expects that the table's third row (index 2) should contain the column headers.
+// The expected column headers are "type", "author(s)", "status", and "created".
+// The function returns true if column headers are found in the, and false otherwise.
 func isColumnFormat(table [][]string) bool {
 	expectedKeys := []string{"type", "author(s)", "status", "created"}
 	if len(table) < 4 {

--- a/ui/src/pages/Specs.tsx
+++ b/ui/src/pages/Specs.tsx
@@ -1,8 +1,8 @@
 import {
-  Navigation,
-  Notification,
-  Spinner,
-  Theme,
+	Navigation,
+	Notification,
+	Spinner,
+	Theme,
 } from "@canonical/react-components";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import qs from "qs";
@@ -13,166 +13,165 @@ import type { ListSpecsResponse } from "../generated/types";
 import useURLState from "../hooks/useURLState";
 import { sortedSet } from "../utils";
 
-const LIMIT = 250;
-const INITIAL_LIMIT = 50;
+const LIMIT = 50;
 
 export const SPEC_TYPES = new Set([
-  "Implementation",
-  "Product Requirement",
-  "Standard",
-  "Informational",
-  "Process",
+	"Implementation",
+	"Product Requirement",
+	"Standard",
+	"Informational",
+	"Process",
 ]);
 export const SPEC_STATUSES = new Set([
-  "Active",
-  "Approved",
-  "Braindump",
-  "Completed",
-  "Drafting",
-  "Obsolete",
-  "Pending review",
-  "Rejected",
+	"Active",
+	"Approved",
+	"Braindump",
+	"Completed",
+	"Drafting",
+	"Obsolete",
+	"Pending review",
+	"Rejected",
 ]);
 
 function Specs() {
-  const { userOptions, setUserOptions } = useURLState();
-  const { data, fetchNextPage, hasNextPage, error, isLoading } =
-    useInfiniteQuery({
-      queryKey: ["specs", userOptions.filter, userOptions.searchQuery],
-      queryFn: async ({ pageParam = 0 }) => {
-        const params = {
-          ...userOptions.filter,
-          searchQuery: userOptions.searchQuery,
-          offset: pageParam,
-          limit: INITIAL_LIMIT,
-        };
-        const queryString = qs.stringify(params, {
-          arrayFormat: "repeat",
-          skipNulls: true,
-          allowEmptyArrays: false,
-        });
-        const res = await fetch(`/api/specs?${queryString}`);
-        const data = (await res.json()) as Promise<ListSpecsResponse>;
-        if (!res.ok) {
-          throw new Error((data as unknown as { message: string }).message);
-        }
-        return data;
-      },
-      getNextPageParam: (lastPage, pages) =>
-        lastPage.specs?.length === LIMIT ? pages.length * LIMIT : undefined,
-      initialPageParam: 0,
-    });
+	const { userOptions, setUserOptions } = useURLState();
+	const { data, fetchNextPage, hasNextPage, error, isLoading } =
+		useInfiniteQuery({
+			queryKey: ["specs", userOptions.filter, userOptions.searchQuery],
+			queryFn: async ({ pageParam = 0 }) => {
+				const params = {
+					...userOptions.filter,
+					searchQuery: userOptions.searchQuery,
+					offset: pageParam,
+					limit: LIMIT,
+				};
+				const queryString = qs.stringify(params, {
+					arrayFormat: "repeat",
+					skipNulls: true,
+					allowEmptyArrays: false,
+				});
+				const res = await fetch(`/api/specs?${queryString}`);
+				const data = (await res.json()) as Promise<ListSpecsResponse>;
+				if (!res.ok) {
+					throw new Error((data as unknown as { message: string }).message);
+				}
+				return data;
+			},
+			getNextPageParam: (lastPage, pages) =>
+				lastPage.specs?.length === LIMIT ? pages.length * LIMIT : undefined,
+			initialPageParam: 0,
+		});
 
-  const totalSpecs = data?.pages[0]?.total || 0;
-  const allSpecs =
-    data?.pages.flatMap((page) => page.specs).filter(Boolean) || [];
-  const { data: authorsData } = useQuery({
-    queryKey: ["authors"],
-    queryFn: async () => {
-      const res = await fetch("/api/specs/authors");
-      return res.json() as Promise<string[]>;
-    },
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
+	const totalSpecs = data?.pages[0]?.total || 0;
+	const allSpecs =
+		data?.pages.flatMap((page) => page.specs).filter(Boolean) || [];
+	const { data: authorsData } = useQuery({
+		queryKey: ["authors"],
+		queryFn: async () => {
+			const res = await fetch("/api/specs/authors");
+			return res.json() as Promise<string[]>;
+		},
+		refetchOnWindowFocus: false,
+		refetchOnMount: false,
+	});
 
-  const { data: teamsData } = useQuery({
-    queryKey: ["teams"],
-    queryFn: async () => {
-      const res = await fetch("/api/specs/teams");
-      return res.json() as Promise<string[]>;
-    },
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-  });
-  const authors = authorsData || [];
-  const teams = teamsData || [];
+	const { data: teamsData } = useQuery({
+		queryKey: ["teams"],
+		queryFn: async () => {
+			const res = await fetch("/api/specs/teams");
+			return res.json() as Promise<string[]>;
+		},
+		refetchOnWindowFocus: false,
+		refetchOnMount: false,
+	});
+	const authors = authorsData || [];
+	const teams = teamsData || [];
 
-  return (
-    <>
-      <a href="#cards" className="p-link--skip">
-        Jump to main content
-      </a>
-      <Navigation
-        logo={{
-          src: "https://assets.ubuntu.com/v1/82818827-CoF_white.svg",
-          title: "Specifications",
-          url: "#",
-        }}
-        items={
-          [
-            // TODO: maybe add these later
-            // { label: "All Docs", url: "/" },
-            // { label: "My Docs", url: "/my-specs" },
-          ]
-        }
-        itemsRight={[
-          {
-            url: "https://docs.google.com/document/d/1lStJjBGW7lyojgBhxGLUNnliUocYWjAZ1VEbbVduX54/edit#heading=h.31hys4te5m58",
-            label: "How to add a new spec",
-          },
-        ]}
-        theme={Theme.DARK}
-      />
-      <main className="l-fluid-breakout">
-        <div className="l-fluid-breakout__toolbar">
-          <div className="l-fluid-breakout__toolbar-items">
-            <div className="l-fluid-breakout__toolbar-item">
-              {totalSpecs} specs
-            </div>
-            <div className="l-fluid-breakout__toolbar-item">
-              <input
-                type="search"
-                value={userOptions.searchQuery}
-                onChange={(e) =>
-                  setUserOptions({
-                    ...userOptions,
-                    searchQuery: e.target.value,
-                  })
-                }
-                placeholder="Search specs..."
-                className="p-search-box__input"
-              />
-            </div>
-          </div>
-        </div>
-        <div className="l-fluid-breakout__aside sticky-sidebar">
-          <Filters
-            authors={sortedSet(new Set(authors))}
-            teams={sortedSet(new Set(teams))}
-            userOptions={userOptions}
-            setUserOptions={setUserOptions}
-          />
-        </div>
-        {isLoading && <Spinner text="Loading..." />}
-        {error && (
-          <Notification severity="negative" title="Error fetching specs">
-            <pre>{error.message}</pre>
-          </Notification>
-        )}
-        <div className="l-fluid-breakout__main" id="cards">
-          <InfiniteScroll
-            dataLength={allSpecs.length}
-            next={fetchNextPage}
-            hasMore={!!hasNextPage}
-            loader={<p className="u-align--center">Loading more specs...</p>}
-          >
-            {allSpecs.map((spec, index) => (
-              <SpecCard key={index} spec={spec} />
-            ))}
-          </InfiniteScroll>
-        </div>
-      </main>
-      <footer className="p-strip is-shallow">
-        <div className="row">
-          <div className="col-12">
-            © {new Date().getFullYear()} Canonical Ltd. Ubuntu and Canonical are
-            registered trademarks of Canonical Ltd.
-          </div>
-        </div>
-      </footer>
-    </>
-  );
+	return (
+		<>
+			<a href="#cards" className="p-link--skip">
+				Jump to main content
+			</a>
+			<Navigation
+				logo={{
+					src: "https://assets.ubuntu.com/v1/82818827-CoF_white.svg",
+					title: "Specifications",
+					url: "#",
+				}}
+				items={
+					[
+						// TODO: maybe add these later
+						// { label: "All Docs", url: "/" },
+						// { label: "My Docs", url: "/my-specs" },
+					]
+				}
+				itemsRight={[
+					{
+						url: "https://docs.google.com/document/d/1lStJjBGW7lyojgBhxGLUNnliUocYWjAZ1VEbbVduX54/edit#heading=h.31hys4te5m58",
+						label: "How to add a new spec",
+					},
+				]}
+				theme={Theme.DARK}
+			/>
+			<main className="l-fluid-breakout">
+				<div className="l-fluid-breakout__toolbar">
+					<div className="l-fluid-breakout__toolbar-items">
+						<div className="l-fluid-breakout__toolbar-item">
+							{totalSpecs} specs
+						</div>
+						<div className="l-fluid-breakout__toolbar-item">
+							<input
+								type="search"
+								value={userOptions.searchQuery}
+								onChange={(e) =>
+									setUserOptions({
+										...userOptions,
+										searchQuery: e.target.value,
+									})
+								}
+								placeholder="Search specs..."
+								className="p-search-box__input"
+							/>
+						</div>
+					</div>
+				</div>
+				<div className="l-fluid-breakout__aside sticky-sidebar">
+					<Filters
+						authors={sortedSet(new Set(authors))}
+						teams={sortedSet(new Set(teams))}
+						userOptions={userOptions}
+						setUserOptions={setUserOptions}
+					/>
+				</div>
+				{isLoading && <Spinner text="Loading..." />}
+				{error && (
+					<Notification severity="negative" title="Error fetching specs">
+						<pre>{error.message}</pre>
+					</Notification>
+				)}
+				<div className="l-fluid-breakout__main" id="cards">
+					<InfiniteScroll
+						dataLength={allSpecs.length}
+						next={fetchNextPage}
+						hasMore={!!hasNextPage}
+						loader={<p className="u-align--center">Loading more specs...</p>}
+					>
+						{allSpecs.map((spec, index) => (
+							<SpecCard key={`${spec.id}-${index}`} spec={spec} />
+						))}
+					</InfiniteScroll>
+				</div>
+			</main>
+			<footer className="p-strip is-shallow">
+				<div className="row">
+					<div className="col-12">
+						© {new Date().getFullYear()} Canonical Ltd. Ubuntu and Canonical are
+						registered trademarks of Canonical Ltd.
+					</div>
+				</div>
+			</footer>
+		</>
+	);
 }
 
 export default Specs;


### PR DESCRIPTION
## Done

- Rename package `googledrive` to `google`
- Change `google.DocumentFirstTable` return structure:
- Change authors, reviewers respresentation instead of names now we use emails
- Parse new column based metadata specs as well

![image](https://github.com/user-attachments/assets/ccbb1254-24cd-4b0e-996c-85099c241f13)


![image](https://github.com/user-attachments/assets/9f9271e9-d829-476a-8212-65292b7088b5)

### For a given table:

| authors | User1, User2, User3 |
|---|---|
| created | 2021-09-13 |
| index | SN114 |

**Previous format:**

```json
{
  "authors": ["User1, User2, User3"],
  "created": ["2021-09-13"],
  "index": ["SN114"],
}
```
  
**New format:**

```json
[
	["authors", "user1@canonical,user2@canonical.com,user3@canonical"],
	["created", "2021-09-13"],
	["index", "SN114"]
]
```

### New specs template with new format:

```json
[
	["Index", "PR001", "", ""],
	["Title", "Specifications - Purpose and Guidance"],
	["Type", "Author(s)", "Status", "Created"],
	[
		"Process",
		"user1@canonical.com,user2@canonical.com,user3@canonical.com",
		"Approved",
		"Apr 22, 2021"
	],
	["", "Reviewer(s)", "Status", "Date"],
	["", "user4@canonical.com", "Approved", "Aug 11, 2023"],
	["", "user3@canonical.com", "Approved", "Aug 11, 2023"],
	["", "user2@canonical.com", "Approved", "Aug 11, 2023"],
	["", "user1@canonical.com", "Approved", "Jul 11, 2023"]
]

```




