### PR TITLE
feat: Add reviewer parsing

### DIFF
--- a/db/models.go
+++ b/db/models.go
@@ -62,5 +62,6 @@ func Rollback(db *gorm.DB) error {
         DROP TRIGGER IF EXISTS update_specs_updated_at ON specs;
         DROP FUNCTION IF EXISTS update_specs_updated_at_column();
         DROP TABLE IF EXISTS specs;
+		DROP TABLE IF EXISTS reviewers;
     `).Error
 }

--- a/db/models.go
+++ b/db/models.go
@@ -62,6 +62,6 @@ func Rollback(db *gorm.DB) error {
         DROP TRIGGER IF EXISTS update_specs_updated_at ON specs;
         DROP FUNCTION IF EXISTS update_specs_updated_at_column();
         DROP TABLE IF EXISTS specs;
-		DROP TABLE IF EXISTS reviewers;
+        DROP TABLE IF EXISTS reviewers;
     `).Error
 }

--- a/db/models.go
+++ b/db/models.go
@@ -12,6 +12,7 @@ type Spec struct {
 	Title              *string        `gorm:"type:text"`
 	Status             *string        `gorm:"type:text"`
 	Authors            pq.StringArray `gorm:"type:text[]"`
+	Reviewers          []Reviewer     `gorm:"foreignKey:SpecID"`
 	SpecType           *string        `gorm:"type:text;column:spec_type"`
 	Team               string         `gorm:"type:text;not null"`
 	GoogleDocID        string         `gorm:"type:text;not null;column:google_doc_id"`
@@ -24,9 +25,16 @@ type Spec struct {
 	SyncedAt           time.Time      `gorm:"not null;default:CURRENT_TIMESTAMP"`
 }
 
+type Reviewer struct {
+	ID     string  `gorm:"type:text;primaryKey"`
+	SpecID string  `gorm:"type:text;index"`
+	Name   *string `gorm:"type:text"`
+	Status *string `gorm:"type:text"`
+}
+
 func Migrate(db *gorm.DB) error {
 	// Create the specs table
-	if err := db.AutoMigrate(&Spec{}); err != nil {
+	if err := db.AutoMigrate(&Spec{}, &Reviewer{}); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.10.0
 	github.com/fatih/color v1.18.0
 	github.com/go-playground/validator v9.31.0+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/lib/pq v1.10.9
 	golang.org/x/oauth2 v0.24.0
@@ -26,7 +27,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/specs/parser.go
+++ b/specs/parser.go
@@ -204,25 +204,25 @@ func parseColumnBasedMetadata(table [][]string, spec *db.Spec) {
 		}
 	}
 
-	reviewerHeaderRow := table[4]
 	if len(table) < 5 {
 		return
 	}
 
+	reviewerHeaderRow := table[4]
 	reviewerNameIdx := -1
-    for i, col := range reviewerHeaderRow {
-        if strings.ToLower(col) == "reviewer(s)" {
-            reviewerNameIdx = i
-            break
-        }
-    }
-    if reviewerNameIdx == -1 {
-        return
-    }
+	for i, col := range reviewerHeaderRow {
+		if strings.ToLower(col) == "reviewer(s)" {
+			reviewerNameIdx = i
+			break
+		}
+	}
+	if reviewerNameIdx == -1 {
+		return
+	}
 
-    var reviewers []db.Reviewer
-    for _, row := range table[5:] {
-        if len(row) != len(reviewerHeaderRow) {
+	var reviewers []db.Reviewer
+	for _, row := range table[5:] {
+		if len(row) != len(reviewerHeaderRow) {
 			continue
 		}
 		reviewer := strings.TrimSpace(row[reviewerNameIdx])
@@ -235,10 +235,10 @@ func parseColumnBasedMetadata(table [][]string, spec *db.Spec) {
 				Status: &status,
 			})
 		}
-    }
-    if len(reviewers) > 0 {
-        spec.Reviewers = reviewers
-    }
+	}
+	if len(reviewers) > 0 {
+		spec.Reviewers = reviewers
+	}
 }
 
 func parseAuthors(values []string) []string {

--- a/specs/parser.go
+++ b/specs/parser.go
@@ -79,7 +79,7 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 		return fmt.Errorf("failed to upsert spec: %w", err)
 	}
 
-	logger.Debug("clear old reviweres")
+	logger.Debug("clear old reviewers")
 	if err := s.DB.Where("spec_id = ?", newSpec.ID).Delete(&db.Reviewer{}).Error; err != nil {
 		return fmt.Errorf("failed to clear old reviewers: %w", err)
 	}


### PR DESCRIPTION
Adds a new reviewer table with a many to one relationship with a spec.

The new logic can be tested with a module like so:

```go
package specs

import (
    "testing"

    "github.com/canonical/specs-v2.canonical.com/db"
    "github.com/stretchr/testify/assert"
)

func TestParseColumnBasedMetadata(t *testing.T) {
    table := [][]string{
        {"Index", "PR001", "", ""},
        {"Title", "Test Spec"},
        {"Type", "Author(s)", "Status", "Created"},
        {"Process", "author@canonical.com", "Approved", "2024-01-01"},
        {"", "Reviewer(s)", "Status", "Date"},
        {"", "reviewer1@canonical.com", "Pending", "2024-06-01"},
        {"", "reviewer2@canonical.com", "Approved", "2024-06-02"},
    }
    spec := db.Spec{ID: "PR001"}
    parseColumnBasedMetadata(table, &spec)

    assert.Len(t, spec.Reviewers, 2)
    assert.Equal(t, "reviewer1@canonical.com", *spec.Reviewers[0].Name)
    assert.Equal(t, "Pending", *spec.Reviewers[0].Status)
    assert.Equal(t, "reviewer2@canonical.com", *spec.Reviewers[1].Name)
    assert.Equal(t, "Approved", *spec.Reviewers[1].Status)
}
```