### PR TITLE
Fix reviewers metadata

### DIFF
--- a/google/client.go
+++ b/google/client.go
@@ -33,7 +33,7 @@ func NewGoogleDrive(config Config) (*Google, error) {
 		Email:        config.ClientEmail,
 		PrivateKey:   []byte(config.PrivateKey),
 		PrivateKeyID: config.PrivateKeyID,
-		Scopes:       []string{drive.DriveReadonlyScope},
+		Scopes:       []string{drive.DriveScope},
 		TokenURL:     google.JWTTokenURL,
 	}
 

--- a/google/client.go
+++ b/google/client.go
@@ -33,8 +33,10 @@ func NewGoogleDrive(config Config) (*Google, error) {
 		Email:        config.ClientEmail,
 		PrivateKey:   []byte(config.PrivateKey),
 		PrivateKeyID: config.PrivateKeyID,
-		Scopes:       []string{drive.DriveScope},
-		TokenURL:     google.JWTTokenURL,
+		// NOTE: Full Drive scope is required (instead of DriveReadonlyScope) to support AddDocComment functionality,
+		// which needs write access to add comments to documents. This expands the permission surface area.
+		Scopes:   []string{drive.DriveScope},
+		TokenURL: google.JWTTokenURL,
 	}
 
 	tokenSource := jwtConfig.TokenSource(context.Background())

--- a/google/helpers.go
+++ b/google/helpers.go
@@ -220,7 +220,18 @@ func (g *Google) DocumentFirstTable(ctx context.Context, fileID string) ([][]str
 	return result, nil
 }
 
-// AddDocComment adds a comment to the given Google Doc.
+// AddDocComment adds a comment to the specified Google Doc.
+//
+// Parameters:
+//   - ctx: The context for the request.
+//   - fileID: The ID of the Google Doc to which the comment will be added.
+//   - content: The text content of the comment to add.
+//
+// This function requires the drive.DriveScope permission to create comments
+// (drive.DriveReadonlyScope is not sufficient).
+//
+// Returns an error if the comment cannot be created, for example due to
+// permission issues, an invalid fileID, or network problems.
 func (g *Google) AddDocComment(ctx context.Context, fileID, content string) error {
 	_, err := g.DriveService.Comments.
 		Create(fileID, &drive.Comment{Content: content}).

--- a/google/helpers.go
+++ b/google/helpers.go
@@ -219,3 +219,12 @@ func (g *Google) DocumentFirstTable(ctx context.Context, fileID string) ([][]str
 
 	return result, nil
 }
+
+func (g *Google) AddDocComment(ctx context.Context, fileID, content string) error {
+	_, err := g.DriveService.Comments.
+		Create(fileID, &drive.Comment{Content: content}).
+		Context(ctx).
+		Fields("id").
+		Do()
+	return err
+}

--- a/google/helpers.go
+++ b/google/helpers.go
@@ -220,6 +220,7 @@ func (g *Google) DocumentFirstTable(ctx context.Context, fileID string) ([][]str
 	return result, nil
 }
 
+// AddDocComment adds a comment to the given Google Doc.
 func (g *Google) AddDocComment(ctx context.Context, fileID, content string) error {
 	_, err := g.DriveService.Comments.
 		Create(fileID, &drive.Comment{Content: content}).

--- a/specs/parser.go
+++ b/specs/parser.go
@@ -227,6 +227,13 @@ func parseColumnBasedMetadata(table [][]string, spec *db.Spec) {
 		}
 		reviewer := strings.TrimSpace(row[reviewerNameIdx])
 		status := strings.TrimSpace(row[reviewerNameIdx+1])
+
+		parts := strings.FieldsFunc(reviewer, AuthorsSplit)
+		if len(parts) != 1 {
+			// ignore if multiple reviewers in one cell
+			continue
+		}
+
 		if len(reviewer) > 4 {
 			reviewers = append(reviewers, db.Reviewer{
 				ID:     uuid.NewString(),


### PR DESCRIPTION
**Summary of changes**
- First commit: Ignore invalid reviewers rows (cells with multiple emails) in the parser.
- Second commit: Also leave a doc comment in Google Docs to tell authors to use one reviewer per row.
- Third commit: Add a safe fallback — when specID is missing (title not in ID - Title format), use the GoogleDocID instead. This prevents sync failures.

**Why this was needed ?**
- Before, if a doc name was wrong it wasn’t a big deal — we only read and parsed, so the spec could just be skipped.
- Now that we add comments (which updates the doc’s modified time), the sync always touches the DB. With an empty specID this breaks (WHERE conditions required, FK errors on reviewers).

The fallback guarantees a non-empty ID, so the upsert and cleanup work safely.

**Extra details**
- This PR also switches the Google Drive scope from DriveReadonlyScope to DriveScope, which is required to allow adding comments to documents. I’ve made this permission change explicit here for visibility.
- Logs a warning when falling back.
- Posts a message in the doc asking the author to rename it properly.
- I’m open to other suggestions if a different approach is preferred :)

See sync.log and screenshot for proof of behavior. 
[sync.log](https://github.com/user-attachments/files/22123498/sync.log)
[screenshot-doc-comments](https://github.com/user-attachments/assets/b6017c9c-0aae-4bf0-949a-2f67bbf63e22)

Fixes #12 