### PR TITLE
WD-26080/Add a Reviewer Filter

### DIFF
--- a/handlers/server.go
+++ b/handlers/server.go
@@ -62,6 +62,7 @@ func NewServer(logger *slog.Logger, config *config.Config, db *gorm.DB) *Server 
 
 	e.GET("/api/specs", server.ListSpecs, server.AuthMiddleware)
 	e.GET("/api/specs/authors", server.SpecAuthors, server.AuthMiddleware)
+	e.GET("/api/specs/reviewers", server.SpecReviewers, server.AuthMiddleware)
 	e.GET("/api/specs/teams", server.SpecTeams, server.AuthMiddleware)
 
 	// Serve static files from dist directory

--- a/ui/src/components/Filters.tsx
+++ b/ui/src/components/Filters.tsx
@@ -11,6 +11,7 @@ import { SPEC_STATUSES, SPEC_TYPES } from "../pages/Specs";
 
 type FiltersProps = {
   authors: string[];
+  reviewers: string[];
   teams: string[];
   userOptions: UserOptions;
   setUserOptions: (options: UserOptions) => void;
@@ -18,6 +19,7 @@ type FiltersProps = {
 
 const Filters = ({
   authors,
+  reviewers,
   teams,
   userOptions,
   setUserOptions,
@@ -100,6 +102,18 @@ const Filters = ({
           ...authors.map((author) => ({ label: author, value: author })),
         ]}
         onChange={(value) => formik.setFieldValue("author", value)}
+      />
+      <CustomSelect
+        value={formik.values.reviewer}
+        label="Reviewer"
+        name="reviewer"
+        id="reviewer"
+        searchable="always"
+        options={[
+          { value: "", label: "All reviewers" },
+          ...reviewers.map((reviewer) => ({ label: reviewer, value: reviewer })),
+        ]}
+        onChange={(value) => formik.setFieldValue("reviewer", value)}
       />
       <Select
         value={formik.values.orderBy}

--- a/ui/src/hooks/useURLState.ts
+++ b/ui/src/hooks/useURLState.ts
@@ -21,6 +21,7 @@ const useURLState = () => {
         status: searchState?.filter?.status || null,
         type: searchState?.filter?.type || null,
         author: searchState?.filter?.author || null,
+        reviewer: searchState?.filter?.reviewer || null,
         orderBy: searchState?.filter?.orderBy || null,
       },
       searchQuery: searchState?.searchQuery || null,

--- a/ui/src/pages/Specs.tsx
+++ b/ui/src/pages/Specs.tsx
@@ -77,6 +77,16 @@ function Specs() {
     refetchOnMount: false,
   });
 
+  const { data: reviewersData } = useQuery({
+    queryKey: ["reviewers"],
+    queryFn: async () => {
+      const res = await fetch("/api/specs/reviewers");
+      return res.json() as Promise<string[]>;
+    },
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+
   const { data: teamsData } = useQuery({
     queryKey: ["teams"],
     queryFn: async () => {
@@ -87,6 +97,7 @@ function Specs() {
     refetchOnMount: false,
   });
   const authors = authorsData || [];
+  const reviewers = reviewersData || [];
   const teams = teamsData || [];
 
   return (
@@ -141,6 +152,7 @@ function Specs() {
           <Filters
             authors={sortedSet(new Set(authors))}
             teams={sortedSet(new Set(teams))}
+            reviewers={sortedSet(new Set(reviewers))}
             userOptions={userOptions}
             setUserOptions={setUserOptions}
           />


### PR DESCRIPTION
>As a specs user I want to filter specs by reviewer from the UI

## Done:
- `/api/reviewers` endpoint to get all reviewers
- New `CustomSelect` in the `Filters` components for reviewer filtering
- Join logic for `/api/specs` to apply reviewer filter

## Issue
[WD-26080](https://warthogs.atlassian.net/browse/WD-26080)

[WD-26080]: https://warthogs.atlassian.net/browse/WD-26080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ