### PR TITLE
fix(specs): update `SearchQuery` handler to group `OR` conditions

### DIFF
--- a/handlers/specs.go
+++ b/handlers/specs.go
@@ -126,12 +126,16 @@ func (s *Server) ListSpecs(c echo.Context) error {
 			searchConfig,
 		)
 
-		query = query.Where(fmt.Sprintf("%s @@ %s", vectorExpr, queryExpr), req.SearchQuery)
+		textFilter := s.DB.Where(
+			fmt.Sprintf("%s @@ %s", vectorExpr, queryExpr), req.SearchQuery,
+		)
 
 		// also add ilike query for the same search fields
 		for _, field := range searchFields {
-			query = query.Or(fmt.Sprintf("%s ILIKE ?", field), "%"+req.SearchQuery+"%")
+			textFilter = textFilter.Or(fmt.Sprintf("%s ILIKE ?", field), "%"+req.SearchQuery+"%")
 		}
+
+		query = query.Where(textFilter)
 	}
 
 	var total int64


### PR DESCRIPTION
The issue was that the multiple `ILIKE` conditions generated by `SearchQuery` are combined with `OR`. When other fields are used (such as `Status`), these are added as `AND` conditions. Therefore, the `OR` conditions must be correctly grouped to allow other conditions to still take place.

Before:

```sql
SELECT
  *
FROM
  "specs"
WHERE
  lower(status) IN ('approved')
  AND to_tsvector(
    'e
nglish', id || ' ' || title || ' ' || team || ' ' || google_doc_name
  ) @@ plainto_tsquery('engli
sh', 'ssdlc')
  OR id ILIKE '%ssdlc%'
  OR title ILIKE '%ssdlc%'
  OR team ILIKE '%ssdlc%'
  OR google_ doc_name ILIKE '%ssdlc%'
ORDER BY
  google_doc_updated_at desc
LIMIT
  50;
```

After:

```sql
SELECT
  *
FROM
  "specs"
WHERE
  lower(status) IN ('approved')
  AND (
    to_tsvector(
      '
english', id || ' ' || title || ' ' || team || ' ' || google_doc_name
    ) @@ plainto_tsquery('engl
ish', 'ssdlc')
    OR id ILIKE '%ssdlc%'
    OR title ILIKE '%ssdlc%'
    OR team ILIKE '%ssdlc%'
    OR google _doc_name ILIKE '%ssdlc%'
  )
ORDER BY
  google_doc_updated_at desc
LIMIT
  50;
```