### PR TITLE
feat: allow for hyphens within team allocations

### DIFF
--- a/specs/parser.go
+++ b/specs/parser.go
@@ -17,7 +17,7 @@ func (s *SyncService) Parse(ctx context.Context, logger *slog.Logger, workerItem
 
 	logger.Debug("processing file")
 
-	parts := strings.SplitN(file.File.Name, "-", 2)
+	parts := strings.SplitN(file.File.Name, " - ", 2)
 	var specId, specTitle string
 	if len(parts) == 2 {
 		specId, specTitle = strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])


### PR DESCRIPTION
changes parsing of the ID to match on content before a hyphen surrounded by spaces: ` - `

The docs on creating a spec already specifies the format to be ``[A-Za-z0-9]* - [A-Za-z0-9 ]*` (pseudo regex), and so by requiring the spaces, we allow for hyphens within squad names. This was already being done in Partner Engineering in the form of, e.g., "PE-NVN1X001 - <spec title>" for a long time.

In discussions between Ricardo Martins and Maksym, it seems like having an ability to filter by the squad within a team (i.e. selecting first PE and then NVN1X) may be a future feature request anyway.