### PR TITLE
Update permissions on juju deploy action.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 ## See ~/.vaultrc in your Juju model
 ## Environment variables:
 # WEBSITE_URL (url)


### PR DESCRIPTION
Update permissions on juju deploy action, so it can push images to GHCR.